### PR TITLE
v0.4.0 Updating background colours and normalising variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.4.0
+------------------------------
+*August 8, 2017*
+
+### Fixed
+- Use of `--offWhite` was inconsistent in it’s casing across variables.  Has now been normalised.
+- `$green--dark` was actually an orange colour (as it was listed wrong in the design spec).
+
+### Changed
+- Updating background variable colour names to be consistent with the naming of other colour variables.
+- `$hr-color` updated to correct shade of grey.
+- `$color-border--interactive` added, for the borders of interactive elements (such as checkboxes)
+
+
+
 v0.3.0
 ------------------------------
 *August 8, 2017*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/fozzie-colour-palette",
   "description": "Brand colour palette for projects at Just Eat",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -9,7 +9,7 @@ $black                        : #000;
 $red                          : #d50525;
 $red--dark                    : #b40e27; // for hover of base $red
 $red--darkest                 : #900b1f; // for focus/active of base $red
-$red--offwhite                : #fee;
+$red--offWhite                : #fee;
 
 $pink                         : #ff5959;
 
@@ -24,10 +24,10 @@ $blue--dark                   : #14509c; // for hover of base $blue
 $blue--darkest                : #14427d; // for focus/active of base $blue
 $blue--light                  : #2bace4;
 $blue--lighter                : #7dcaeb;
-$blue--offwhite               : #edf5ff;
+$blue--offWhite               : #edf5ff;
 
 $green                        : #04822c;
-$green--dark                  : #ae3713; // for hover of base $green
+$green--dark                  : #036823; // for hover of base $green
 $green--darkest               : #02531c; // for focus/active of base $green
 $green--light                 : #00ac41;
 $green--offWhite              : #f2fae2;
@@ -68,15 +68,18 @@ $color-secondary              : $blue;
 $color-text                   : $grey--dark;
 $color-text--hint             : $grey--mid;
 $color-headings               : $grey--darkest;
+
 $color-bg                     : $grey--offWhite;
-$color-bg--component          : $grey--lightest;
-$color-border                 : $grey--lighter;
+$color-bg--component          : $white;
+$color-bg--accept             : $green--light;
+$color-bg--notification       : $yellow--light;
+$color-bg--info               : $blue--offWhite;
+$color-bg--error              : $red--offWhite;
+
+$color-border                 : $grey--lightest;
+$color-border--interactive    : $grey--lighter;
 $color-disabled               : $grey--lighter;
 $color-shadow                 : $grey--lightest;
-
-$color-alert-bg               :  $yellow--light;
-$color-statusMsg              :  $orange--light;
-$color-infoMsg                :  $blue--offwhite;
 
 $color-btas-primary           : $purple;
 $color-btas-bg                : $purple--light;
@@ -92,4 +95,4 @@ $color-selection              : inherit;
 $color-selection-bg           : inherit;
 
 // <hr> border color
-$hr-color                     : $color-border;
+$hr-color                     : $grey--lightest;


### PR DESCRIPTION
### Fixed
- Use of `--offWhite` was inconsistent in it’s casing across variables.  Has now been normalised.
- `$green--dark` was actually an orange colour (as it was listed wrong in the design spec).

### Changed
- Updating background variable colour names to be consistent with the naming of other colour variables.
- `$hr-color` updated to correct shade of grey.
- `$color-border--interactive` added, for the borders of interactive elements (such as checkboxes)


## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [created]
- [x] This code has been checked with regard to our accessibility standards
  - [x] The colours added/changed have been colour contrast tested [[link]](http://webaim.org/resources/contrastchecker/)
