### PR TITLE
v0.8.1 - Updating focus outline colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.8.1
+------------------------------
+*October 24, 2017*
+
+### Updated
+- `$color-focus-outline` updated to `$orange--light`.
+
+
 v0.8.0
 ------------------------------
 *October 20, 2017*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/fozzie-colour-palette",
   "description": "Brand colour palette for projects at Just Eat",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:justeat/fozzie-colour-palette.git"

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -91,9 +91,8 @@ $color-link-hover             : $blue--dark;
 $color-link-active            : $blue--darkest;
 // $color-link-visited           : $color-link-default; // should we use this?
 
-// Focus outline colour – currently defined as default blue that chrome uses
-// Note this doesn't need to be defined in colour palette as it shouldn't be reused
-$color-focus-outline          : #5b9dd9;
+// Focus outline colour
+$color-focus-outline          : $orange--light;
 
 // Text Selection – currently defined as brower default
 $color-selection              : inherit;


### PR DESCRIPTION
### Updated
- `$color-focus-outline` updated to `$orange--light`.

- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards
  - [x] The colours added/changed have been colour contrast tested [[link]](http://webaim.org/resources/contrastchecker/)
