### PR TITLE
CPD-10667 `$color-bg--accept` alias is corrected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.9.1
+------------------------------
+*January 31, 2018*
+
+### Fixed
+- `$color-bg--accept` alias is corrected.
+
+
 v0.9.0
 ------------------------------
 *October 27, 2017*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/fozzie-colour-palette",
   "description": "Brand colour palette for projects at Just Eat",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:justeat/fozzie-colour-palette.git"

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -75,7 +75,7 @@ $color-headings--highlight    : $brand--red;  // only to be used at large font s
 
 $color-bg                     : $grey--offWhite;
 $color-bg--component          : $white;
-$color-bg--accept             : $green--light;
+$color-bg--accept             : $green--offWhite;
 $color-bg--notification       : $yellow--light;
 $color-bg--info               : $blue--offWhite;
 $color-bg--error              : $red--offWhite;


### PR DESCRIPTION


`$color-bg--accept` alias is corrected.

## UI Review Checks

Old 
![screen shot 2018-01-31 at 1 50 05 pm](https://user-images.githubusercontent.com/1676440/35626497-c8fd6efc-068d-11e8-9d26-5495e90c8f60.png)

New

![screen shot 2018-01-31 at 1 49 49 pm](https://user-images.githubusercontent.com/1676440/35626501-cbd3eff2-068d-11e8-99d6-92adde6e5ead.png)



- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [created|updated]
- [x] This code has been checked with regard to our accessibility standards
  - [x] The colours added/changed have been colour contrast tested [[link]](http://webaim.org/resources/contrastchecker/)
