### PR TITLE
v3.0.0-beta.3 - Updating colours to be more inline with PIE colour scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.0-beta.3
+------------------------------
+*July 20, 2020*
+
+### Changed
+- Updated colours to be more in-line with PIE redesign colour scheme. The next step to move to full `v3` will be to integrate the PIE colour tokens into this package so the colours being used are from the same source as the apps.
+
+
 v3.0.0-beta.2
 ------------------------------
 *June 18, 2020*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/fozzie-colour-palette",
   "description": "Brand colour palette for projects at Just Eat",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "files": [
     "src"
   ],

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -13,39 +13,39 @@ $brand--orange                : #ff8000;
 // Web Orange
 // NOT fully AA accessibility compliant but available for text 18px font-size or for incidental background colours
 $orange                       : #f36d00;
-$orange--dark                 : #cb5b00;
+$orange--dark                 : #df6400;
 $orange--darkest              : #a44900;
 
 // Fully accessible orange
 $orange--aa                   : #cd4900;
-$orange--aa--dark             : #c44600;
+$orange--aa--dark             : #bc4300;
 $orange--aa--darkest          : #8b3100;
 
-$orange--offWhite             : #ffe6cc; // for background highlight and warnings
+$orange--offWhite             : #ffead4; // for background highlight and warnings
 
 
-$blue                         : #0b74a1;
-$blue--dark                   : #0a6f9a; // for hover of base $blue
-$blue--darkest                : #09658d; // for focus/active of base $blue
-$blue--offWhite               : #edf7fc;
-$blue--offWhite--dark         : #e3edf2; // for hover of base $blue--offWhite
-$blue--offWhite--darkest      : #d0d8dd; // for focus/active of base $blue--offWhite
+$blue                         : #125fca;
+$blue--dark                   : #0f4fa9; // for hover of base $blue
+$blue--darkest                : #0d4089; // for focus/active of base $blue
+$blue--offWhite               : #e7f1fe;
+$blue--offWhite--dark         : #dde7f4; // for hover of base $blue--offWhite
+$blue--offWhite--darkest      : #cad3df; // for focus/active of base $blue--offWhite
 
-$red                          : #e11725;
+$red                          : #d50525;
 $red--offWhite                : #ffe9ea;
 
-$green                        : #04824b;
-$green--offWhite              : #ecffeb;
+$green                        : #006631;
+$green--offWhite              : #e5faef;
 
 $yellow--offWhite             : #fff9df;
 
 // Greys – listed from lightest to darkest - these are the full range of greys we can use
-$grey--offWhite               : #f5f5f5;
-$grey--lighter                : #eaeaea;
-$grey--light                  : #cacaca;
-$grey--mid                    : #757575;
-$grey--dark                   : #535353;
-$grey--darkest                : #333;
+$grey--offWhite               : #f9fafb;
+$grey--lighter                : #f1f2f4;
+$grey--light                  : #e2e6e9;
+$grey--mid                    : #c5ccd3;
+$grey--dark                   : #5e6b77;
+$grey--darkest                : #2a3846;
 
 
 // BTA Brand Colours - only to be used in-line with BTA colours


### PR DESCRIPTION
### Changed
- Updated colours to be more in-line with PIE redesign colour scheme. The next step to move to full `v3` will be to integrate the PIE colour tokens into this package so the colours being used are from the same source as the apps.

## UI Review Checks

<img width="1041" alt="Screen Shot 2020-07-20 at 12 45 43" src="https://user-images.githubusercontent.com/805184/87934439-f69af400-ca86-11ea-9594-4bde0022b033.png">

- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards
  - [x] The colours added/changed have been colour contrast tested [[link]](http://webaim.org/resources/contrastchecker/)
