### PR TITLE
v3.0.0 – $blue--light and $grey--midDark added and release new theme from beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.0.0
+------------------------------
+*October 19, 2020*
+
+### Added
+- `$blue--light` variable (used for link outlines).
+- `$grey--midDark` variable (to match full array of PIE colours).
+
+### Changed
+- Moved `v3` beta to full release, now the themes have consolidated into one PIE + JET theme.
+
+
 v3.0.0-beta.6
 ------------------------------
 *July 30, 2020*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/fozzie-colour-palette",
   "description": "Brand colour palette for projects at Just Eat",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0",
   "files": [
     "src"
   ],

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -24,6 +24,7 @@ $orange--aa--darkest          : #8b3100;
 $orange--offWhite             : #ffead4; // for background highlight and warnings
 
 
+$blue--light                  : #4996fd; // used for outlines
 $blue                         : #125fca;
 $blue--dark                   : #0f4fa9; // for hover of base $blue
 $blue--darkest                : #0d4089; // for focus/active of base $blue
@@ -44,6 +45,7 @@ $grey--offWhite               : #f9fafb;
 $grey--lighter                : #f1f2f4;
 $grey--light                  : #e2e6e9;
 $grey--mid                    : #c5ccd3;
+$grey--midDark                : #929faa;
 $grey--dark                   : #5e6b77;
 $grey--darkest                : #2a3846;
 
@@ -93,7 +95,7 @@ $color-link-active            : $blue--darkest;
 // $color-link-visited           : $color-link-default; // should we use this?
 
 // Focus outline colour
-$color-focus-outline          : $blue;
+$color-focus-outline          : $blue--light;
 
 // Text Selection – currently defined as browser default
 $color-selection              : inherit;


### PR DESCRIPTION
### Added
- `$blue--light` variable (used for link outlines).
- `$grey--midDark` variable (to match full array of PIE colours).

### Changed
- Moved `v3` beta to full release, now the themes have consolidated into one PIE + JET theme.


## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [ ] UI Documentation has been created (will be done as part of PIE documentation)
- [x] This code has been checked with regard to our accessibility standards
  - [x] The colours added/changed have been colour contrast tested [[link]](http://webaim.org/resources/contrastchecker/)
